### PR TITLE
fix: Relax minor version constraint

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             )
         ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", .upToNextMinor(from: "2.1.0")),
+        .package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", from: "2.1.0"),
             ],
         targets: [
             // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
All of the Kitura-Credentials plugins depend on major v2 of Kitura-Credentials, except this one.  The latest versions could not be used together, as the plugins that were updated for Type-safe Middleware require v2.2 of Credentials or higher, whereas this one required v2.1.x.